### PR TITLE
chore: fix codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-/* @defenseunicorns/uds-core
+* @defenseunicorns/uds-core


### PR DESCRIPTION
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file

/* only protects the top level files.